### PR TITLE
Decoupled thermostat

### DIFF
--- a/src/gromacs/mdlib/coupling.cpp
+++ b/src/gromacs/mdlib/coupling.cpp
@@ -675,7 +675,13 @@ real calc_temp(real ekin, real nrdf)
 {
     if (nrdf > 0)
     {
-        return (2.0 * ekin) / (nrdf * gmx::c_boltz);
+        if(getenv("GMX_DECOUPLE_XZ")!=NULL) {                          
+                  return (2.0 * ekin) / (1 * nrdf * gmx::c_boltz / 3.);
+        }else if(getenv("GMX_DECOUPLE_X")!=NULL) {                     
+                  return (2.0 * ekin) / (2 * nrdf * gmx::c_boltz / 3.);
+        } else {                                                       
+                  return (2.0 * ekin) / (nrdf * gmx::c_boltz);         
+               }                                                       
     }
     else
     {

--- a/src/gromacs/mdlib/tgroup.cpp
+++ b/src/gromacs/mdlib/tgroup.cpp
@@ -93,8 +93,16 @@ real sum_ekin(const t_grpopts* opts, gmx_ekindata_t* ekind, real* dekindlambda, 
             }
             m_add(tcstat->ekinf, ekind->ekin, ekind->ekin);
 
-            tcstat->Th = calc_temp(trace(tcstat->ekinh), nd);
-            tcstat->T  = calc_temp(trace(tcstat->ekinf), nd);
+            if(getenv("GMX_DECOUPLE_XZ")!=NULL) {                                         
+                      tcstat->Th = calc_temp(tcstat->ekinh[1][1], nd);                    
+                      tcstat->T  = calc_temp(tcstat->ekinf[1][1], nd);                    
+            } else if(getenv("GMX_DECOUPLE_X")!=NULL) {                                   
+                      tcstat->Th = calc_temp(tcstat->ekinh[1][1]+tcstat->ekinh[2][2], nd);
+                      tcstat->T  = calc_temp(tcstat->ekinf[1][1]+tcstat->ekinf[2][2], nd);
+            } else  {                                                                     
+                      tcstat->Th = calc_temp(trace(tcstat->ekinh), nd);                   
+                      tcstat->T  = calc_temp(trace(tcstat->ekinf), nd);                   
+                   }
 
             /* after the scaling factors have been multiplied in, we can remove them */
             if (bEkinAveVel)

--- a/src/gromacs/mdlib/update.cpp
+++ b/src/gromacs/mdlib/update.cpp
@@ -636,10 +636,20 @@ static void updateMDLeapfrogGeneral(int                                 start,
                 dtPressureCouple * multiplyVectorByMatrix(parrinelloRahmanM, vRel);
         for (int d = 0; d < DIM; d++)
         {
-            real vNew = (lg * vRel[d]
-                         + (f[n][d] * invMassPerDim[n][d] * dt - factorNH * vRel[d]
+            real vNew=0.0;                                                                                          
+            static int test=1;                                                                                             
+            if(getenv("GMX_DECOUPLE_XZ")!=NULL && d != 1) {                                                                
+                    if (test) { printf(" **** DECOUPLING XZ TRANSLATIONAL DOF FROM THERMOSTAT ****\n\n\n\n\n\n"); test=0; }
+                    vNew = lg*vRel[d] + (f[n][d]*invMassPerDim[n][d]*dt - parrinelloRahmanScaledVelocity[d]);              
+            } else if(getenv("GMX_DECOUPLE_X")!=NULL && d == 0) {                                                          
+                    if (test) { printf(" **** DECOUPLING X TRANSLATIONAL DOF FROM THERMOSTAT ****\n\n\n\n\n\n"); test=0; } 
+                    vNew = lg*vRel[d] + (f[n][d]*invMassPerDim[n][d]*dt - parrinelloRahmanScaledVelocity[d]);              
+            }  else {                                                                                                      
+                    if (test) { printf(" **** NOT DECOUPLING !!!  ****\n\n\n\n\n\n"); test=0; }                            
+                    vNew = (lg*vRel[d] + (f[n][d]*invMassPerDim[n][d]*dt - factorNH*vRel[d]                                
                             - parrinelloRahmanScaledVelocity[d]))
                         / (1 + factorNH);
+            }
             switch (accelerationType)
             {
                 case AccelerationType::None: break;


### PR DESCRIPTION
To decouple the X or both X and Z direction of Nos′e-Hoover thermostat by export the corresponding environment variable before running gromacs, like this:
export GMX_DECOUPLE_X=1 ; gmx mdrun …
or
export GMX_DECOUPLE_XZ=1 ; gmx mdrun …


